### PR TITLE
Add exported `bone_name` property to `IKEffector`

### DIFF
--- a/src/godot_ik_effector.h
+++ b/src/godot_ik_effector.h
@@ -18,6 +18,9 @@ public:
 		FULL_TRANSFORM // Apply this node3ds transform.
 	};
 
+	String get_bone_name() const;
+	void set_bone_name(String p_name);
+
 	int get_bone_idx() const;
 	void set_bone_idx(int p_bone_idx);
 
@@ -40,9 +43,12 @@ public:
 	PackedStringArray _get_configuration_warnings() const override;
 
 protected:
+	void _validate_property(PropertyInfo &p_property) const;
+
 	static void _bind_methods();
 
 private:
+	String bone_name = "";
 	int bone_idx = 0;
 	int chain_length = 2;
 	TransformMode transform_mode = TransformMode::POSITION_ONLY;


### PR DESCRIPTION
To simplify and make it easier to work with, I added an exported string that functions like the one in BoneAttachment3D. (psst - don't tell anyone I copied code from there 😉 )

![image](https://github.com/user-attachments/assets/73315e5b-6caf-462d-833c-7cc669d574f7)
![image](https://github.com/user-attachments/assets/9dd89d4b-2574-4b73-9c10-1d9d69a440f4)
