### PR TITLE
Add bone_name property to IKConstraint

### DIFF
--- a/src/godot_ik_constraint.h
+++ b/src/godot_ik_constraint.h
@@ -19,20 +19,27 @@ public:
 		FORWARD = 1
 	};
 	virtual PackedVector3Array apply(Vector3 p_parent_bone_pos, Vector3 p_bone_pos, Vector3 p_child_bone_pos, int direction);
+
+	String get_bone_name() const;
+	void set_bone_name(String p_name);
+
 	int get_bone_idx() const;
 	void set_bone_idx(int p_bone_idx);
 
 	void set_ik_controller(GodotIK *p_ik_controller);
 	GodotIK *get_ik_controller() const;
 
-	godot::Skeleton3D *get_skeleton() const;
+	Skeleton3D *get_skeleton() const;
 
 protected:
+	void _validate_property(PropertyInfo &p_property) const;
+
 	static void _bind_methods();
 	GDVIRTUAL4RC(PackedVector3Array, apply, Vector3, Vector3, Vector3, int);
 	bool apply_method_implemented = false;
 
 private:
+	String bone_name = "";
 	int bone_idx = 0;
 	GodotIK *ik_controller = nullptr;
 }; // ! class GodotIKConstraint


### PR DESCRIPTION
Just like in the IkEffector, added the bone_name property for easier use and bone selection that works just in the Godot's default BoneAttachment3D.

![image](https://github.com/user-attachments/assets/d2f1d23c-4bfe-4067-86c8-0f2fdb840205)
![image](https://github.com/user-attachments/assets/f385da00-55af-4480-aa47-fb96c1f0fbe8)
