### PR TITLE
Prioritize chain bones in depth sort for transform application

### DIFF
--- a/src/godot_ik.h
+++ b/src/godot_ik.h
@@ -71,7 +71,6 @@ private:
 	// Bone length relative to parent. Root has no bone length.
 	Vector<float> bone_lengths;
 	HashMap<int, Vector<int>> grouped_by_position;
-	Vector<int> bone_depths;
 	Vector<int> indices_by_depth;
 
 	Vector<bool> needs_processing;


### PR DESCRIPTION
Sorts `GodotIK::indices_by_depth` in `initialize_if_dirty()` so that bones involved in IK chains are processed before non-chain bones at the same depth during the `apply_positions()` step.

This ensures that rotation is applied based on valid, chain-driven transforms first, avoiding cases where helper or grouped bones with zero-length directions overwrite parent transforms.

Fixes #54
