### PR TITLE
Propagate Positions Across Chains & Resolve Inter-Chain Dependencies

### DIFF
--- a/src/godot_ik.cpp
+++ b/src/godot_ik.cpp
@@ -176,6 +176,8 @@ void GodotIK::propagate_positions_from_chain_ancestors() {
 
 		ERR_FAIL_COND_MSG(rest_dir.length() == 0 || cur_dir.length() == 0, "[GodotIK] Can't propergate transforms with zero length base bone. Please open an issue.");
 
+		// This simulates the actual end transform and propagates it through the chain.
+		// Same as in final apply_positions post-pass. Note: Might not work if deprecated use_global_poles = true.
 		Quaternion adjustment = Quaternion(rest_dir, cur_dir);
 		Basis new_rotation = adjustment * rest_ancestor.basis;
 		Transform3D new_transform = Transform3D(new_rotation, positions[idx_ancestor_bone]);

--- a/src/godot_ik.cpp
+++ b/src/godot_ik.cpp
@@ -533,7 +533,7 @@ void GodotIK::initialize_if_dirty() {
 					comp_depths(p_depths), comp_in_chain(p_in_chain) {
 			}
 
-			// Respect depth AND make bones in chains shallower
+			// Respect depth and make bones that are in chains shallower. Shallower -> Processed first.
 			bool operator()(int a, int b) const {
 				return comp_depths[a] < comp_depths[b] || (comp_depths[a] == comp_depths[b] && comp_in_chain.has(a) && !comp_in_chain.has(b));
 			}

--- a/src/godot_ik.cpp
+++ b/src/godot_ik.cpp
@@ -807,7 +807,7 @@ void GodotIK::make_dirty() {
 // ------------ Helpers ----------------
 
 Vector<int> GodotIK::calculate_bone_depths(Skeleton3D *p_skeleton) {
-    ERR_FAIL_NULL_V_MSG(p_skeleton, Vector<int>(), "[GodotIK] No skeleton during calculate_bone_depths.");
+	ERR_FAIL_NULL_V_MSG(p_skeleton, Vector<int>(), "[GodotIK] No skeleton during calculate_bone_depths.");
 
 	int bone_count = p_skeleton->get_bone_count();
 	if (bone_count == 0) {
@@ -901,7 +901,7 @@ int GodotIK::get_current_iteration() {
 }
 
 void GodotIK::add_external_root(GodotIKRoot *p_root) {
-    ERR_FAIL_COND_MSG(this->is_ancestor_of(p_root) || p_root->is_ancestor_of(this), "[GodotIK] can't be ancestor of its external root or vise versa.");
+	ERR_FAIL_COND_MSG(this->is_ancestor_of(p_root) || p_root->is_ancestor_of(this), "[GodotIK] can't be ancestor of its external root or vise versa.");
 	external_roots.push_back(p_root);
 	if (get_skeleton()) {
 		initialize_if_dirty();

--- a/src/godot_ik.h
+++ b/src/godot_ik.h
@@ -28,6 +28,7 @@ private:
 		Vector3 effector_position;
 		Vector<GodotIKConstraint *> constraints;
 		int closest_parent_in_chain = -1;
+		int closest_parents_child_in_chain = -1;
 	};
 
 public:

--- a/src/godot_ik.h
+++ b/src/godot_ik.h
@@ -28,7 +28,7 @@ private:
 		Vector3 effector_position;
 		Vector<GodotIKConstraint *> constraints;
 		int closest_parent_in_chain = -1;
-		int closest_parents_child_in_chain = -1;
+		int pivot_child_in_ancestor = -1;
 	};
 
 public:
@@ -96,7 +96,7 @@ private:
 	Callable callable_deinitialize;
 
 	// update ------
-	void propergate_positions_from_chain_ancestors();
+	void propagate_positions_from_chain_ancestors();
 	void solve_forward();
 	void solve_backward();
 	void apply_positions();

--- a/src/godot_ik.h
+++ b/src/godot_ik.h
@@ -27,6 +27,7 @@ private:
 		GodotIKEffector *effector;
 		Vector3 effector_position;
 		Vector<GodotIKConstraint *> constraints;
+		int closest_parent_in_chain = -1;
 	};
 
 public:
@@ -94,7 +95,7 @@ private:
 	Callable callable_deinitialize;
 
 	// update ------
-
+	void propergate_positions_from_chain_ancestors();
 	void solve_forward();
 	void solve_backward();
 	void apply_positions();


### PR DESCRIPTION
This PR introduces handling of inter-chain dependencies by ensuring that position changes in one chain properly propagate to dependent chains, even when they are offset by intermediate bones.

Ensures intermediate bones (not part of any chain) receive correct positional updates.

Also implemented:
Sorting of chains by shallowest bone to improve order of resolution.

(equal to #58, but for positions rather than rotations) 

Should later be improved with caching but has zero overhead in setups without inter-chain dependencies.

Follow up to #58
Closes #59