### PR TITLE
Fix Shared Pivot Transform Propagation & Multi-Chain Effector Support

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -84,12 +84,14 @@ ConstructorInitializerAllOnOneLineOrOnePerLine: true
 #   - KJ_IF_MAYBE
 # IncludeBlocks:   Preserve
 IncludeCategories:
-  - Regex:           '".*"'
+  - Regex:           '^<godot_cpp/.*>'
     Priority:        1
-  - Regex:           '^<.*\.h>'
+  - Regex:           '".*"'
     Priority:        2
-  - Regex:           '^<.*'
+  - Regex:           '^<.*\.h>'
     Priority:        3
+  - Regex:           '^<.*'
+    Priority:        4
 # IncludeIsMainRegex: '(Test)?$'
 # IncludeIsMainSourceRegex: ''
 # IndentAccessModifiers: false

--- a/src/godot_ik.cpp
+++ b/src/godot_ik.cpp
@@ -1029,15 +1029,15 @@ Basis GodotIK::get_working_global_basis_unsafe(
 		const Vector<Transform3D> &p_initial_transforms) {
 	BoneCache &cache = bone_caches[p_bone_idx];
 	
-	// Caching logic:
+	// Caching logic: Caching is disabled. We need a virtual skeleton now.
 	//
 	// Post-pass: This is safe. All bone positions are finalized before this is used.
 	// During position propagation: This is acceptable *for now*; because multiple iterations approximate the correct result over time.
 	// Caveat: If iteration_count small, propagation (only complex setups) may be slightly off due to stale transforms.
 	// TODO: Carefully revisit this. Consider tree-walking for precise per-pass updates vs. caching tradeoff.
-	if (cache.iteration == current_iteration && cache.child_index == p_child_idx) {
-		return cache.basis;
-	}
+	// if (cache.iteration == current_iteration && cache.child_index == p_child_idx) {
+	// 	return cache.basis;
+	// }
 
 	int parent_idx = p_skeleton->get_bone_parent(p_bone_idx);
 

--- a/src/godot_ik.cpp
+++ b/src/godot_ik.cpp
@@ -971,5 +971,5 @@ void GodotIK::apply_effector_rotation(const GodotIKEffector *effector, Vector<Tr
 		parent_transform = transforms[parent_idx];
 	}
 
-	bone_transform.basis = get_effector_target_global_basis(effector, skeleton, bone_transform, parent_transform);
+	bone_transform.basis = bone_transform.basis.slerp(get_effector_target_global_basis(effector, skeleton, bone_transform, parent_transform), effector->get_influence());
 }

--- a/src/godot_ik.cpp
+++ b/src/godot_ik.cpp
@@ -152,8 +152,8 @@ void GodotIK::propagate_positions_from_chain_ancestors() {
 			continue;
 		}
 
-		ERR_FAIL_INDEX(0, chain.bones.size());
-		int root_idx = chain.bones[chain.bones.size() - 1];
+		ERR_FAIL_INDEX(0, chain.size());
+		int root_idx = chain.bones[chain.size() - 1];
 		int ancestor_idx = root_idx; // include root_idx in updates
 
 		Vector<int> list_to_closest_parent; // TODO: Cache root to ancestor list for performance
@@ -201,7 +201,7 @@ void GodotIK::solve_backward() {
 	// Chains are sorted by shallowest bone; iterate in reverse for backward pass
 	for (int idx_chain = chains.size() - 1; idx_chain >= 0; idx_chain--) {
 		IKChain &chain = chains.write[idx_chain];
-		if (chain.bones.size() == 0 || chain.effector->get_influence() == 0.) {
+		if (chain.size() == 0 || chain.effector->get_influence() == 0.) {
 			continue;
 		}
 		if (!chain.effector->is_active()) {
@@ -213,7 +213,7 @@ void GodotIK::solve_backward() {
 		if (chain.constraints[leaf_idx]) {
 			apply_constraint(chain, leaf_idx, GodotIKConstraint::Dir::BACKWARD);
 		}
-		for (int i = 1; i < chain.bones.size() - 1; ++i) {
+		for (int i = 1; i < chain.size() - 1; ++i) {
 			int idx_child = chain.bones[i - 1];
 			int idx_bone = chain.bones[i];
 			float length = bone_lengths[idx_child];
@@ -236,11 +236,11 @@ void GodotIK::solve_forward() {
 		if (!chain.effector->is_active() || chain.effector->get_influence() == 0.) {
 			continue;
 		}
-		int root_idx = chain.bones.size() - 1;
+		int root_idx = chain.size() - 1;
 		if (root_idx >= 0 && chain.constraints[root_idx]) {
-			apply_constraint(chain, chain.bones.size() - 1, GodotIKConstraint::Dir::FORWARD);
+			apply_constraint(chain, chain.size() - 1, GodotIKConstraint::Dir::FORWARD);
 		}
-		for (int i = chain.bones.size() - 2; i >= 0; --i) {
+		for (int i = chain.size() - 2; i >= 0; --i) {
 			int idx_parent = chain.bones[i + 1];
 			int idx_bone = chain.bones[i];
 			float length = bone_lengths[idx_bone];
@@ -440,7 +440,7 @@ void GodotIK::apply_positions() {
 }
 
 void GodotIK::apply_constraint(const IKChain &p_chain, int p_idx_in_chain, GodotIKConstraint::Dir p_dir) {
-	if (p_idx_in_chain >= p_chain.bones.size()) {
+	if (p_idx_in_chain >= p_chain.size()) {
 		return;
 	}
 	GodotIKConstraint *constraint = p_chain.constraints[p_idx_in_chain];
@@ -458,7 +458,7 @@ void GodotIK::apply_constraint(const IKChain &p_chain, int p_idx_in_chain, Godot
 	Vector3 pos_bone = positions[idx_bone];
 	Vector3 pos_child;
 
-	if (p_idx_in_chain < p_chain.bones.size() - 1) {
+	if (p_idx_in_chain < p_chain.size() - 1) {
 		idx_parent = p_chain.bones[p_idx_in_chain + 1];
 		pos_parent = positions[idx_parent];
 	} else { // no parent. We are the root. Check skeleton for parent then.
@@ -567,10 +567,10 @@ void GodotIK::initialize_if_dirty() {
 		bone_to_chain_map.reserve(skeleton->get_bone_count());
 		for (int idx_chain = 0; idx_chain < chains.size(); idx_chain++) {
 			const IKChain &chain = chains[idx_chain];
-			if (chain.effector->get_bone_idx() == 0 || chain.bones.size() == 0){
+			if (chain.effector->get_bone_idx() == 0 || chain.size() == 0){
 				continue;
 			}
-			for (int idx_in_chain = 0; idx_in_chain < chain.bones.size(); ++idx_in_chain) {
+			for (int idx_in_chain = 0; idx_in_chain < chain.size(); ++idx_in_chain) {
 				int bone_idx = chain.bones[idx_in_chain];
 				if (bone_to_chain_map.has(bone_idx)) {
 					continue;
@@ -582,10 +582,10 @@ void GodotIK::initialize_if_dirty() {
 
 	// assign closest_parent in chain
 	for (IKChain &chain : chains) {
-		if (chain.bones.size() == 0) {
+		if (chain.size() == 0) {
 			continue;
 		}
-		int root_idx = chain.bones[chain.bones.size() - 1];
+		int root_idx = chain.bones[chain.size() - 1];
 		int ancestor_idx = skeleton->get_bone_parent(root_idx);
 		while (ancestor_idx != -1 && !bone_to_chain_map.has(ancestor_idx)) {
 			ancestor_idx = skeleton->get_bone_parent(ancestor_idx);
@@ -750,7 +750,7 @@ void GodotIK::initialize_chains() {
 		}
 
 		// add constraints to current effector
-		new_chain.constraints.resize(new_chain.bones.size());
+		new_chain.constraints.resize(new_chain.size());
 		new_chain.constraints.fill(nullptr);
 		int effector_pole_count = 0;
 		for (int i = 0; i < effector->get_child_count(); i++) {
@@ -758,7 +758,7 @@ void GodotIK::initialize_chains() {
 			if (child->is_class("GodotIKConstraint")) {
 				GodotIKConstraint *constraint = Object::cast_to<GodotIKConstraint>(child);
 				int placement_in_chain = -1;
-				for (int idx_chain = 0; idx_chain < new_chain.bones.size(); idx_chain++) {
+				for (int idx_chain = 0; idx_chain < new_chain.size(); idx_chain++) {
 					if (new_chain.bones[idx_chain] == constraint->get_bone_idx()) {
 						placement_in_chain = idx_chain;
 						break;

--- a/src/godot_ik.cpp
+++ b/src/godot_ik.cpp
@@ -1,6 +1,6 @@
 #include "godot_ik.h"
-#include "godot_cpp/variant/basis.hpp"
 
+#include <godot_cpp/variant/basis.hpp>
 #include <godot_ik_effector.h>
 #include <godot_cpp/classes/performance.hpp>
 #include <godot_cpp/classes/skeleton3d.hpp>

--- a/src/godot_ik.h
+++ b/src/godot_ik.h
@@ -134,7 +134,7 @@ private:
 	Vector<int> calculate_bone_depths(Skeleton3D *p_skeleton);
 	bool compare_by_depth(int p_a, int p_b, const Vector<int> &p_depths);
 	Vector<Node *> get_nested_children_dsf(Node *p_base) const;
-	float compute_constraint_step_influence(float total_influence, int iteration_count);
+	float compute_influence_in_step(float total_influence, int iteration_count);
 
 	Basis get_effector_target_global_basis(
 			const GodotIKEffector *effector,

--- a/src/godot_ik.h
+++ b/src/godot_ik.h
@@ -140,6 +140,7 @@ private:
 			const Skeleton3D *skeleton,
 			const Transform3D &effector_global_transform,
 			const Transform3D &parent_global_transform) const;
+	void apply_effector_rotation(const GodotIKEffector *effector, Vector<Transform3D> &transforms, const Skeleton3D *skeleton);
 }; // ! class GodotIK
 
 } // namespace godot

--- a/src/godot_ik.h
+++ b/src/godot_ik.h
@@ -83,7 +83,6 @@ private:
 	Vector<Transform3D> initial_transforms;
 	Vector<Vector3> positions;
 	Vector<GodotIKEffector *> effectors;
-	Vector<Vector<GodotIKEffector *>> bone_effector_map;
 	StringName performance_monitor_name;
 	/** identity_idx is used as an extra element (at index bone_count) to represent a "null" or identity transform.
 	*** This extra element is initialized as follows:

--- a/src/godot_ik.h
+++ b/src/godot_ik.h
@@ -12,6 +12,7 @@
 #include <godot_cpp/templates/hash_map.hpp>
 #include <godot_cpp/templates/vector.hpp>
 #include <godot_cpp/variant/packed_string_array.hpp>
+#include <godot_cpp/variant/transform3d.hpp>
 
 namespace godot {
 
@@ -134,6 +135,12 @@ private:
 	bool compare_by_depth(int p_a, int p_b, const Vector<int> &p_depths);
 	Vector<Node *> get_nested_children_dsf(Node *p_base) const;
 	float compute_constraint_step_influence(float total_influence, int iteration_count);
+
+	Basis get_effector_target_global_basis(
+			const GodotIKEffector *effector,
+			const Skeleton3D *skeleton,
+			const Transform3D &effector_global_transform,
+			const Transform3D &parent_global_transform) const;
 }; // ! class GodotIK
 
 } // namespace godot

--- a/src/godot_ik.h
+++ b/src/godot_ik.h
@@ -29,6 +29,9 @@ private:
 		Vector<GodotIKConstraint *> constraints;
 		int closest_parent_in_chain = -1;
 		int pivot_child_in_ancestor = -1;
+		inline int size() const {
+			return bones.size();
+		}
 	};
 
 public:

--- a/src/godot_ik.h
+++ b/src/godot_ik.h
@@ -33,6 +33,9 @@ private:
 		inline int size() const {
 			return bones.size();
 		}
+		inline bool is_empty() const {
+			return size() == 0;
+		}
 	};
 
 public:
@@ -82,6 +85,7 @@ private:
 	Vector<bool> needs_processing;
 	Vector<Transform3D> initial_transforms;
 	Vector<Vector3> positions;
+	Vector<int> primary_child_list;
 	Vector<GodotIKEffector *> effectors;
 	StringName performance_monitor_name;
 	/** identity_idx is used as an extra element (at index bone_count) to represent a "null" or identity transform.
@@ -141,6 +145,12 @@ private:
 			const Transform3D &effector_global_transform,
 			const Transform3D &parent_global_transform) const;
 	void apply_effector_rotation(const GodotIKEffector *effector, Vector<Transform3D> &transforms, const Skeleton3D *skeleton);
+	Transform3D get_working_global_transform(
+			int bone_idx,
+			const Skeleton3D *skeleton,
+			const Vector<Vector3> &positions,
+			const Vector<Transform3D> &initial_transforms,
+			HashMap<int, Transform3D> &cache) const;
 }; // ! class GodotIK
 
 } // namespace godot

--- a/src/godot_ik.h
+++ b/src/godot_ik.h
@@ -30,9 +30,10 @@ private:
 		GodotIKEffector *effector;
 		Vector3 effector_position;
 		Vector<GodotIKConstraint *> constraints;
-		int32_t closest_parent_in_chain = -1;
-		int32_t pivot_child_in_ancestor = -1;
-		int32_t closest_anchestor_chain_idx;
+		int32_t ancestor_chain_bone_idx = -1;
+		int16_t ancestor_child_bone_index = -1;
+		bool ancestor_is_effector = false;
+		const IKChain * ancestor_chain = nullptr;
 
 		inline int size() const {
 			return bones.size();

--- a/src/godot_ik.h
+++ b/src/godot_ik.h
@@ -102,7 +102,7 @@ private:
 	void propagate_positions_from_chain_ancestors();
 	void solve_forward();
 	void solve_backward();
-	void apply_positions();
+	void post_pass();
 
 	// ! update --------
 

--- a/src/godot_ik_effector.cpp
+++ b/src/godot_ik_effector.cpp
@@ -122,6 +122,7 @@ void GodotIKEffector::set_transform_mode(TransformMode p_transform_mode) {
 
 void GodotIKEffector::set_ik_controller(GodotIK *p_ik_controller) {
 	ik_controller = p_ik_controller;
+	update_configuration_warnings();
 }
 
 GodotIK *GodotIKEffector::get_ik_controller() const {

--- a/src/godot_ik_root.cpp
+++ b/src/godot_ik_root.cpp
@@ -1,4 +1,5 @@
 #include "godot_ik_root.h"
+#include "godot_cpp/variant/callable_method_pointer.hpp"
 #include "godot_ik.h"
 
 using namespace godot;
@@ -10,12 +11,16 @@ void GodotIKRoot::_notification(int p_notification) {
 		}
 		GodotIK *new_ik_controller = get_node<GodotIK>(ik_controller_path);
 		if (new_ik_controller) {
-			new_ik_controller->add_external_root(this);
+			if (!new_ik_controller->is_node_ready()) {
+				new_ik_controller->connect("ready", callable_mp(new_ik_controller, &GodotIK::add_external_root).bind(this));
+			} else {
+				new_ik_controller->add_external_root(this);
+			}
 		}
 		ik_controller = new_ik_controller;
 	}
-	if (p_notification == NOTIFICATION_EXIT_TREE){
-		if (ik_controller){
+	if (p_notification == NOTIFICATION_EXIT_TREE) {
+		if (ik_controller) {
 			ik_controller->remove_external_root(this);
 		}
 	}


### PR DESCRIPTION
This pull request refactors and extends solver to correctly handle complex skeletons with offset dependent chains and offset dependent effector bones. It resolves said propagation inconsistencies and ensures influence is respected in all transform modes.

### What’s Fixed and Improved

* Correct transform propagation when effector bones are shared yet offset across multiple chains.

  > Example: Hands and fingers.
* Full support for overlapping IK chains and shared pivots.

  > Example: Arms and head.
* Influence respected for effector rotation and position, including partial values.

  > `transform_mode` now works with `IKEffector::influence`.
* Accurate transform propagation from ancestor chains.

  > Slower, but correct. Evaluating iteration vs performance. 8 iterations with 5 interdependent chains: 50 us measured in release. Scripted constraints still biggest bottleneck due to gdscript communication overhead and simply gdscript.
* In-place effector transforms.

  > Required partial refactor.
* Replaced `closest_parent_in_chain` with clear ancestor fields.

### Architectural Changes

* Added: `ancestor_chain_bone_idx`, `ancestor_child_bone_index`, `ancestor_is_effector`
* Rewrote `propagate_positions_from_chain_ancestors()`
* Removed `GodotIK::bone_map`
* Renamed and refactored `apply_positions` → `post_pass()`
* Minor cleanup (clang-format, includes, naming)

### Tradeoffs

* Slower propagation, uncached tree-walks
* Slight inaccuracy with `iteration_count = 1`, converges after
* Zero-influence edge cases not optimized

### Versioning

* Backwards compatible but reworked: Target `v1.4.0`
* Replaces broken shared effector behavior in `v1.3.1`
